### PR TITLE
import UIKit header in MDCSwipeToChooseDelegate.h

### DIFF
--- a/MDCSwipeToChoose/Public/Views/MDCSwipeToChooseDelegate.h
+++ b/MDCSwipeToChoose/Public/Views/MDCSwipeToChooseDelegate.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import "MDCSwipeDirection.h"
 
 /*!


### PR DESCRIPTION
I needed to import UIKit header in the MDCSwipeToChooseDelegate header file before my app would compile.
