### PR TITLE
View would pop back when using mdc_swipe.

### DIFF
--- a/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
+++ b/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
@@ -55,7 +55,7 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
     // Moves the view to the minimum point exceeding the threshold.
     // Transforms and executes pan callbacks as well.
     void (^animations)(void) = ^{
-        CGPoint translation = [self mdc_translationExceedingThreshold:self.mdc_options.threshold
+        CGPoint translation = [self mdc_translationExceedingThreshold:self.mdc_options.threshold*1.25f
                                                             direction:direction];
         self.center = MDCCGPointAdd(self.center, translation);
         [self mdc_rotateForTranslation:translation


### PR DESCRIPTION
I was having an issue with the view popping back when using mdc_swipe. It was not moving far enough for some reason and the mdc_directionOfExceededThreshold call would return MDCSwipeDirectionNone. I just increased the threshold used to move the view inside the mdc_swipe call.

Signed-off-by: Chris Pomerantz chris@fluiddataconcepts.com
