### PR TITLE
Fix threshold property documentation - pixels to points

### DIFF
--- a/MDCSwipeToChoose/Public/Options/MDCSwipeOptions.h
+++ b/MDCSwipeToChoose/Public/Options/MDCSwipeOptions.h
@@ -68,8 +68,8 @@ typedef void (^MDCSwipeToChooseOnChosenBlock)(MDCSwipeResult *state);
 @property (nonatomic, assign) UIViewAnimationOptions swipeAnimationOptions;
 
 /*!
- * The distance, in pixels, that a view must be panned in order to constitue a selection.
- * For example, if the `threshold` is `100.f`, panning the view `101.f` pixels to the right
+ * The distance, in points, that a view must be panned in order to constitue a selection.
+ * For example, if the `threshold` is `100.f`, panning the view `101.f` points to the right
  * is considered a selection in the `MDCSwipeDirectionRight` direction. A default value is
  * provided in the `-init` method.
  */


### PR DESCRIPTION
Changed documentation of threshold property - the property is defined in points (not as pixels). That is:
"threshold of 100.f means that you have to pan view 101.f points", that is 101 pixels on non-retina iPhones and 202 pixels on retina ones.

Tested experimentally.
