### PR TITLE
Account for original transform of view when swiping

### DIFF
--- a/MDCSwipeToChoose/Internal/State/MDCViewState.h
+++ b/MDCSwipeToChoose/Internal/State/MDCViewState.h
@@ -34,6 +34,7 @@ extern const MDCRotationDirection MDCRotationTowardsCenter;
  * The center of the view when the pan gesture began.
  */
 @property (nonatomic, assign) CGPoint originalCenter;
+@property (nonatomic, assign) CGAffineTransform originalTransform;
 
 /*!
  * When the pan gesture originates at the top half of the view, the view rotates

--- a/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
+++ b/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
@@ -133,7 +133,7 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
                           delay:0.0
                         options:self.mdc_options.swipeCancelledAnimationOptions
                      animations:^{
-                         self.transform = CGAffineTransformIdentity;
+                         self.transform = self.mdc_viewState.originalTransform;
                          self.center = self.mdc_viewState.originalCenter;
                      } completion:^(BOOL finished) {
                          id<MDCSwipeToChooseDelegate> delegate = self.mdc_options.delegate;
@@ -189,7 +189,7 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
 - (void)mdc_rotateForTranslation:(CGPoint)translation
                rotationDirection:(MDCRotationDirection)rotationDirection {
     CGFloat rotation = MDCDegreesToRadians(translation.x/100 * self.mdc_options.rotationFactor);
-    self.transform = CGAffineTransformRotate(CGAffineTransformIdentity,
+    self.transform = CGAffineTransformRotate(self.mdc_viewState.originalTransform,
                                              rotationDirection * rotation);
 }
 
@@ -229,6 +229,7 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
 
     if (panGestureRecognizer.state == UIGestureRecognizerStateBegan) {
         self.mdc_viewState.originalCenter = view.center;
+        self.mdc_viewState.originalTransform = view.transform;
 
         // If the pan gesture originated at the top half of the view, rotate the view
         // away from the center. Otherwise, rotate towards the center.


### PR DESCRIPTION
So in our app we create a stack of swipe-to-choose views and give them all a slight rotation to give a sort of "stack of photos" vibe. But then when you start swiping one it would rotate back to square. This PR fixes that.
