### PR TITLE
Remove .m files from public_header_files in .podspec

### DIFF
--- a/MDCSwipeToChoose.podspec
+++ b/MDCSwipeToChoose.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/modocache'
   s.source = { :git => 'https://github.com/modocache/MDCSwipeToChoose.git', :tag => "v#{s.version}" }
   s.source_files = 'MDCSwipeToChoose/**/*.{h,m}'
-  s.public_header_files = 'MDCSwipeToChoose/Public/**/*.{h,m}'
+  s.public_header_files = 'MDCSwipeToChoose/Public/**/*.h'
   s.requires_arc = true
   s.platform = :ios, '7.0'
   s.framework = 'UIKit'


### PR DESCRIPTION
CocoaPods now generates umbrella headers for pods (<a href="http://blog.cocoapods.org/Pod-Authors-Guide-to-CocoaPods-Frameworks/">documented here</a>), based off of the public_header_files array in the podspec.
The default umbrella header that is generated for MDCSwipeToChoose includes .m files, which in turn causes include statements like <code>#import "MDCSwipeToChoose.m"</code> to appear in it (which causes the build to fail). 
This commit fixes that issue by removing the .m files from the public_header_files array and thus allows to MDCSwipeToChoose to build under the new version of CocoaPods.