### PR TITLE
assign initial transform value to self.mdc_viewState.originalTransform t...

### DIFF
--- a/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
+++ b/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
@@ -39,6 +39,8 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
     self.mdc_options = options ? options : [MDCSwipeOptions new];
     self.mdc_viewState = [MDCViewState new];
     self.mdc_viewState.originalCenter = self.center;
+    //assign value ,otherwise originalTransform will have wrong transform matrix to work with
+    self.mdc_viewState.originalTransform = self.transform;
 
     [self mdc_setupPanGestureRecognizer];
 }


### PR DESCRIPTION
Assign initial transform value to self.mdc_viewState.originalTransform to fix bug when try to rotate view programmatically. 
