### PR TITLE
Fixed mdc_swipe animation

### DIFF
--- a/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
+++ b/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
@@ -39,7 +39,7 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
     self.mdc_options = options ? options : [MDCSwipeOptions new];
     self.mdc_viewState = [MDCViewState new];
     self.mdc_viewState.originalCenter = self.center;
-    self.mdc_viewState.originalTransform = self.transform;
+    self.mdc_viewState.originalTransform = self.layer.transform;
 
     [self mdc_setupPanGestureRecognizer];
 }

--- a/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
+++ b/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
@@ -39,6 +39,7 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
     self.mdc_options = options ? options : [MDCSwipeOptions new];
     self.mdc_viewState = [MDCViewState new];
     self.mdc_viewState.originalCenter = self.center;
+    self.mdc_viewState.originalTransform = self.transform;
 
     [self mdc_setupPanGestureRecognizer];
 }


### PR DESCRIPTION
The animation when swiping programmatically using mdc_swipe did not work properly, unless the user had actually started panning the view and the cancelled.

The root cause was that originalTransform was only set in mdc_onSwipeToChoosePanGestureRecognizer. It should also be set in mdc_swipeToChooseSetup just like originalCenter.