### PR TITLE
Add option to show images for like/nope view

### DIFF
--- a/MDCSwipeToChoose/Public/Options/MDCSwipeToChooseViewOptions.h
+++ b/MDCSwipeToChoose/Public/Options/MDCSwipeToChooseViewOptions.h
@@ -49,6 +49,12 @@
 @property (nonatomic, strong) UIColor *likedColor;
 
 /*!
+ * The image used to displayed in the `likeView`. If this is present, it will take
+ * precedence over the likeText
+ */
+@property (nonatomic, copy) UIImage *likedImage;
+
+/*!
  * The rotation angle of the `likedView`. A default value is provided in the
  * `-init` method.
  */
@@ -65,6 +71,12 @@
  * `-init` method.
  */
 @property (nonatomic, strong) UIColor *nopeColor;
+
+/*!
+ * The image used to displayed in the `nopeView`. If this is present, it will take
+ * precedence over the nopeText
+ */
+@property (nonatomic, copy) UIImage *nopeImage;
 
 /*!
  * The rotation angle of the `nopeView`. A default value is provided in the

--- a/MDCSwipeToChoose/Public/Views/MDCSwipeToChooseView.m
+++ b/MDCSwipeToChoose/Public/Views/MDCSwipeToChooseView.m
@@ -31,6 +31,7 @@
 
 static CGFloat const MDCSwipeToChooseViewHorizontalPadding = 10.f;
 static CGFloat const MDCSwipeToChooseViewTopPadding = 20.f;
+static CGFloat const MDCSwipeToChooseViewImageTopPadding = 100.f;
 static CGFloat const MDCSwipeToChooseViewLabelWidth = 65.f;
 
 @interface MDCSwipeToChooseView ()
@@ -48,7 +49,7 @@ static CGFloat const MDCSwipeToChooseViewLabelWidth = 65.f;
         [self setupView];
         [self constructImageView];
         [self constructLikedView];
-        [self constructNopeImageView];
+        [self constructNopeView];
         [self setupSwipeToChoose];
     }
     return self;
@@ -74,28 +75,44 @@ static CGFloat const MDCSwipeToChooseViewLabelWidth = 65.f;
 }
 
 - (void)constructLikedView {
+    CGFloat yOrigin = (self.options.likedImage ? MDCSwipeToChooseViewImageTopPadding : MDCSwipeToChooseViewTopPadding);
+
     CGRect frame = CGRectMake(MDCSwipeToChooseViewHorizontalPadding,
-                              MDCSwipeToChooseViewTopPadding,
-                              CGRectGetMidX(_imageView.bounds),
+                              yOrigin,
+                              CGRectGetMidX(self.imageView.bounds),
                               MDCSwipeToChooseViewLabelWidth);
-    self.likedView = [[UIView alloc] initWithFrame:frame];
-    [self.likedView constructBorderedLabelWithText:self.options.likedText
-                                             color:self.options.likedColor
-                                             angle:self.options.likedRotationAngle];
+    if (self.options.likedImage) {
+        self.likedView = [[UIImageView alloc] initWithImage:self.options.likedImage];
+        self.likedView.frame = frame;
+        self.likedView.contentMode = UIViewContentModeScaleAspectFit;
+    } else {
+        self.likedView = [[UIView alloc] initWithFrame:frame];
+        [self.likedView constructBorderedLabelWithText:self.options.likedText
+                                                 color:self.options.likedColor
+                                                 angle:self.options.likedRotationAngle];
+    }
     self.likedView.alpha = 0.f;
     [self.imageView addSubview:self.likedView];
 }
 
-- (void)constructNopeImageView {
+- (void)constructNopeView {
     CGFloat width = CGRectGetMidX(self.imageView.bounds);
-    CGFloat xOrigin = CGRectGetMaxX(_imageView.bounds) - width - MDCSwipeToChooseViewHorizontalPadding;
-    self.nopeView = [[UIImageView alloc] initWithFrame:CGRectMake(xOrigin,
-                                                                  MDCSwipeToChooseViewTopPadding,
-                                                                  width,
-                                                                  MDCSwipeToChooseViewLabelWidth)];
-    [self.nopeView constructBorderedLabelWithText:self.options.nopeText
-                                            color:self.options.nopeColor
-                                            angle:self.options.nopeRotationAngle];
+    CGFloat xOrigin = CGRectGetMaxX(self.imageView.bounds) - width - MDCSwipeToChooseViewHorizontalPadding;
+    CGFloat yOrigin = (self.options.nopeImage ? MDCSwipeToChooseViewImageTopPadding : MDCSwipeToChooseViewTopPadding);
+    CGRect frame = CGRectMake(xOrigin,
+                              yOrigin,
+                              width,
+                              MDCSwipeToChooseViewLabelWidth);
+    if (self.options.nopeImage) {
+        self.nopeView = [[UIImageView alloc] initWithImage:self.options.nopeImage];
+        self.nopeView.frame = frame;
+        self.nopeView.contentMode = UIViewContentModeScaleAspectFit;
+    } else {
+        self.nopeView = [[UIView alloc] initWithFrame:frame];
+        [self.nopeView constructBorderedLabelWithText:self.options.nopeText
+                                                color:self.options.nopeColor
+                                                angle:self.options.nopeRotationAngle];
+    }
     self.nopeView.alpha = 0.f;
     [self.imageView addSubview:self.nopeView];
 }

--- a/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
+++ b/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
@@ -171,7 +171,7 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
 
 - (void)mdc_executeOnPanBlockForTranslation:(CGPoint)translation {
     if (self.mdc_options.onPan) {
-        CGFloat thresholdRatio = MIN(1.f, fabsf(translation.x)/self.mdc_options.threshold);
+        CGFloat thresholdRatio = MIN(1.f, fabs(translation.x)/self.mdc_options.threshold);
 
         MDCSwipeDirection direction = MDCSwipeDirectionNone;
         if (translation.x > 0.f) {


### PR DESCRIPTION
Arbitrary images are now supported in the place of like/nope text. This
also fixes a few warnings found in Xcode 6.3 regarding fabsf/fabs.