### PR TITLE
Fix animation of views off-screen

### DIFF
--- a/MDCSwipeToChoose/Public/Options/MDCSwipeOptions.m
+++ b/MDCSwipeToChoose/Public/Options/MDCSwipeOptions.m
@@ -57,7 +57,8 @@
                               delay:0.0
                             options:options
                          animations:^{
-                             state.view.frame = destination;
+                             state.view.center = CGPointMake(CGRectGetMidX(destination),
+                                                             CGRectGetMidY(destination));
                          } completion:^(BOOL finished) {
                              if (finished) {
                                  [state.view removeFromSuperview];


### PR DESCRIPTION
When animating a view to leave the screen, only change the center
of the view rather than the frame. Because there is a transform on
the view (in most cases), changing the frame is not safe.