### PR TITLE
Allowing all subclasses of UIView as content

### DIFF
--- a/Examples/LikedOrNope/LikedOrNope/Controllers/ChoosePersonViewController.m
+++ b/Examples/LikedOrNope/LikedOrNope/Controllers/ChoosePersonViewController.m
@@ -203,7 +203,7 @@ static const CGFloat ChoosePersonButtonVerticalPadding = 20.f;
     UIButton *button = [UIButton buttonWithType:UIButtonTypeRoundedRect];
     UIImage *image = [UIImage imageNamed:@"nope"];
     button.frame = CGRectMake(ChoosePersonButtonHorizontalPadding,
-                              CGRectGetMaxY(self.backCardView.frame) + ChoosePersonButtonVerticalPadding,
+                              CGRectGetMaxY(self.frontCardView.frame) + ChoosePersonButtonVerticalPadding,
                               image.size.width,
                               image.size.height);
     [button setImage:image forState:UIControlStateNormal];
@@ -222,7 +222,7 @@ static const CGFloat ChoosePersonButtonVerticalPadding = 20.f;
     UIButton *button = [UIButton buttonWithType:UIButtonTypeRoundedRect];
     UIImage *image = [UIImage imageNamed:@"liked"];
     button.frame = CGRectMake(CGRectGetMaxX(self.view.frame) - image.size.width - ChoosePersonButtonHorizontalPadding,
-                              CGRectGetMaxY(self.backCardView.frame) + ChoosePersonButtonVerticalPadding,
+                              CGRectGetMaxY(self.frontCardView.frame) + ChoosePersonButtonVerticalPadding,
                               image.size.width,
                               image.size.height);
     [button setImage:image forState:UIControlStateNormal];

--- a/Examples/SwiftLikedOrNope/SwiftLikedOrNope/ChoosePersonViewController.swift
+++ b/Examples/SwiftLikedOrNope/SwiftLikedOrNope/ChoosePersonViewController.swift
@@ -163,7 +163,7 @@ class ChoosePersonViewController: UIViewController, MDCSwipeToChooseDelegate {
     func constructNopeButton() -> Void{
         let button:UIButton =  UIButton.buttonWithType(UIButtonType.System) as! UIButton
         let image:UIImage = UIImage(named:"nope")!
-        button.frame = CGRectMake(ChoosePersonButtonHorizontalPadding, CGRectGetMaxY(self.backCardView.frame) + ChoosePersonButtonVerticalPadding, image.size.width, image.size.height)
+        button.frame = CGRectMake(ChoosePersonButtonHorizontalPadding, CGRectGetMaxY(self.frontCardView.frame) + ChoosePersonButtonVerticalPadding, image.size.width, image.size.height)
         button.setImage(image, forState: UIControlState.Normal)
         button.tintColor = UIColor(red: 247.0/255.0, green: 91.0/255.0, blue: 37.0/255.0, alpha: 1.0)
         button.addTarget(self, action: "nopeFrontCardView", forControlEvents: UIControlEvents.TouchUpInside)
@@ -173,7 +173,7 @@ class ChoosePersonViewController: UIViewController, MDCSwipeToChooseDelegate {
     func constructLikedButton() -> Void{
         let button:UIButton = UIButton.buttonWithType(UIButtonType.System) as! UIButton
         let image:UIImage = UIImage(named:"liked")!
-        button.frame = CGRectMake(CGRectGetMaxX(self.view.frame) - image.size.width - ChoosePersonButtonHorizontalPadding, CGRectGetMaxY(self.backCardView.frame) + ChoosePersonButtonVerticalPadding, image.size.width, image.size.height)
+        button.frame = CGRectMake(CGRectGetMaxX(self.view.frame) - image.size.width - ChoosePersonButtonHorizontalPadding, CGRectGetMaxY(self.frontCardView.frame) + ChoosePersonButtonVerticalPadding, image.size.width, image.size.height)
         button.setImage(image, forState:UIControlState.Normal)
         button.tintColor = UIColor(red: 29.0/255.0, green: 245.0/255.0, blue: 106.0/255.0, alpha: 1.0)
         button.addTarget(self, action: "likeFrontCardView", forControlEvents: UIControlEvents.TouchUpInside)

--- a/MDCSwipeToChoose/Public/Views/MDCSwipeToChooseView.h
+++ b/MDCSwipeToChoose/Public/Views/MDCSwipeToChooseView.h
@@ -35,7 +35,7 @@
 /*!
  * The main image to be displayed and then "liked" or "disliked".
  */
-@property (nonatomic, strong) UIImageView *imageView;
+@property (nonatomic, strong) UIView *contentView;
 
 /*!
  * The "liked" view, which fades in as the `MDCSwipeToChooseView` is panned to the right.

--- a/MDCSwipeToChoose/Public/Views/MDCSwipeToChooseView.m
+++ b/MDCSwipeToChoose/Public/Views/MDCSwipeToChooseView.m
@@ -47,7 +47,7 @@ static CGFloat const MDCSwipeToChooseViewLabelWidth = 65.f;
     if (self) {
         _options = options ? options : [MDCSwipeToChooseViewOptions new];
         [self setupView];
-        [self constructImageView];
+        [self constructContentView];
         [self constructLikedView];
         [self constructNopeView];
         [self setupSwipeToChoose];
@@ -68,10 +68,10 @@ static CGFloat const MDCSwipeToChooseViewLabelWidth = 65.f;
                                                  alpha:1.f].CGColor;
 }
 
-- (void)constructImageView {
-    _imageView = [[UIImageView alloc] initWithFrame:self.bounds];
-    _imageView.clipsToBounds = YES;
-    [self addSubview:_imageView];
+- (void)constructContentView {
+    _contentView = [[UIView alloc] initWithFrame:self.bounds];
+    _contentView.clipsToBounds = YES;
+    [self addSubview:_contentView];
 }
 
 - (void)constructLikedView {
@@ -79,7 +79,7 @@ static CGFloat const MDCSwipeToChooseViewLabelWidth = 65.f;
 
     CGRect frame = CGRectMake(MDCSwipeToChooseViewHorizontalPadding,
                               yOrigin,
-                              CGRectGetMidX(self.imageView.bounds),
+                              CGRectGetMidX(self.contentView.bounds),
                               MDCSwipeToChooseViewLabelWidth);
     if (self.options.likedImage) {
         self.likedView = [[UIImageView alloc] initWithImage:self.options.likedImage];
@@ -92,12 +92,12 @@ static CGFloat const MDCSwipeToChooseViewLabelWidth = 65.f;
                                                  angle:self.options.likedRotationAngle];
     }
     self.likedView.alpha = 0.f;
-    [self.imageView addSubview:self.likedView];
+    [self.contentView addSubview:self.likedView];
 }
 
 - (void)constructNopeView {
-    CGFloat width = CGRectGetMidX(self.imageView.bounds);
-    CGFloat xOrigin = CGRectGetMaxX(self.imageView.bounds) - width - MDCSwipeToChooseViewHorizontalPadding;
+    CGFloat width = CGRectGetMidX(self.contentView.bounds);
+    CGFloat xOrigin = CGRectGetMaxX(self.contentView.bounds) - width - MDCSwipeToChooseViewHorizontalPadding;
     CGFloat yOrigin = (self.options.nopeImage ? MDCSwipeToChooseViewImageTopPadding : MDCSwipeToChooseViewTopPadding);
     CGRect frame = CGRectMake(xOrigin,
                               yOrigin,
@@ -114,7 +114,7 @@ static CGFloat const MDCSwipeToChooseViewLabelWidth = 65.f;
                                                 angle:self.options.nopeRotationAngle];
     }
     self.nopeView.alpha = 0.f;
-    [self.imageView addSubview:self.nopeView];
+    [self.contentView addSubview:self.nopeView];
 }
 
 - (void)setupSwipeToChoose {


### PR DESCRIPTION
Hi,

I've made a change that will allow all UIView subclasses to be the content of an MDC swipe card.  I did this because on our current project we are also allowing there to be video and text.

In addition, I came across an issue when building (based off of example project) where if the data source only has one element in the array, there will be no back card, and because the "nope" and "like" buttons' frames are based off the back card frame, they will be at the top of the screen.  I fixed that by basing those frames' off of the front card, which will always exist.