### PR TITLE
Programatic Swipe not firing callback fix

### DIFF
--- a/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
+++ b/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
@@ -66,7 +66,7 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
 
     // Finalize upon completion of the animations.
     void (^completion)(BOOL) = ^(BOOL finished) {
-        if (finished) { [self mdc_finalizePosition]; }
+        if (finished) { [self mdc_finalizePositionForDirection:direction]; }
     };
 
     [UIView animateWithDuration:self.mdc_options.swipeAnimationDuration
@@ -114,6 +114,10 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
 
 - (void)mdc_finalizePosition {
     MDCSwipeDirection direction = [self mdc_directionOfExceededThreshold];
+    [self mdc_finalizePositionForDirection:direction];
+}
+
+- (void)mdc_finalizePositionForDirection:(MDCSwipeDirection)direction {
     switch (direction) {
         case MDCSwipeDirectionRight:
         case MDCSwipeDirectionLeft: {


### PR DESCRIPTION
Resolves a bug for situations where programmatic swipes don't trigger a delegate callback.

In my project (Swift 2.0, Xcode 7.1) mdc_directionOfExceededThreshold is not returning a reliable value because mdc_viewState.originalCenter is always 0 when set and is only updated upon the pan gesture recogniser firing. I'm not sure why this is occurring (I'm using Autolayout, perhaps that's why?)
This small refactor fixes the bug and allows for more internal flexibility.

Should also resolve #34 

P.S Awesome Framework.