### PR TITLE
Made the view:view shouldBeChosenWithDirection:direction more appropr…

### DIFF
--- a/MDCSwipeToChoose/Public/Views/MDCSwipeToChooseDelegate.h
+++ b/MDCSwipeToChoose/Public/Views/MDCSwipeToChooseDelegate.h
@@ -27,10 +27,12 @@
 - (void)viewDidCancelSwipe:(UIView *)view;
 
 /*!
- * Sent before a choice is made. Return `NO` to prevent the choice from being made,
- * and `YES` otherwise.
+ * Sent before a choice is made. Return `no` to prevent the choice from being made,
+ * and `yes` otherwise.
  */
-- (BOOL)view:(UIView *)view shouldBeChosenWithDirection:(MDCSwipeDirection)direction;
+- (void)view:(UIView *)view shouldBeChosenWithDirection:(MDCSwipeDirection)direction
+         yes:(void (^)(void))yes
+          no:(void (^)(void))no;
 
 /*!
  * Sent after a choice is made. When using the default `MDCSwipeOptions`, the `view`

--- a/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
+++ b/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
@@ -147,27 +147,25 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
 - (void)mdc_exitSuperviewFromTranslation:(CGPoint)translation {
     MDCSwipeDirection direction = [self mdc_directionOfExceededThreshold];
     id<MDCSwipeToChooseDelegate> delegate = self.mdc_options.delegate;
-    if ([delegate respondsToSelector:@selector(view:shouldBeChosenWithDirection:)]) {
-        BOOL should = [delegate view:self shouldBeChosenWithDirection:direction];
-        if (!should) {
+    if ([delegate respondsToSelector:@selector(view:shouldBeChosenWithDirection:yes:no:)]) {
+        [delegate view:self shouldBeChosenWithDirection:direction yes:^{
+            MDCSwipeResult *state = [MDCSwipeResult new];
+            state.view = self;
+            state.translation = translation;
+            state.direction = direction;
+            state.onCompletion = ^{
+                if ([delegate respondsToSelector:@selector(view:wasChosenWithDirection:)]) {
+                    [delegate view:self wasChosenWithDirection:direction];
+                }
+            };
+            self.mdc_options.onChosen(state);
+        } no:^{
             [self mdc_returnToOriginalCenter];
             if (self.mdc_options.onCancel != nil){
                 self.mdc_options.onCancel(self);
             }
-            return;
-        }
+        }];
     }
-
-    MDCSwipeResult *state = [MDCSwipeResult new];
-    state.view = self;
-    state.translation = translation;
-    state.direction = direction;
-    state.onCompletion = ^{
-        if ([delegate respondsToSelector:@selector(view:wasChosenWithDirection:)]) {
-            [delegate view:self wasChosenWithDirection:direction];
-        }
-    };
-    self.mdc_options.onChosen(state);
 }
 
 - (void)mdc_executeOnPanBlockForTranslation:(CGPoint)translation {


### PR DESCRIPTION
Made the view:view shouldBeChosenWithDirection:direction more appropriate for using with async calls. Instead of a boolean return value there are now two callbacks which must be called to decide, whether the view should continue out of the screen or return to the original center. We need this because we do a async API call in the shouldBeChoosen delegate method, which can fail or succeed.