### PR TITLE
Use Core Animation to translate the layer, rather than manipulating the view's frame

### DIFF
--- a/MDCSwipeToChoose/Internal/State/MDCViewState.h
+++ b/MDCSwipeToChoose/Internal/State/MDCViewState.h
@@ -30,11 +30,8 @@ extern const MDCRotationDirection MDCRotationTowardsCenter;
 
 @interface MDCViewState : NSObject
 
-/*!
- * The center of the view when the pan gesture began.
- */
-@property (nonatomic, assign) CGPoint originalCenter;
 @property (nonatomic, assign) CATransform3D originalTransform;
+@property (nonatomic, assign) CGPoint translation;
 
 /*!
  * When the pan gesture originates at the top half of the view, the view rotates

--- a/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
+++ b/MDCSwipeToChoose/Public/Views/UIView+MDCSwipeToChoose.m
@@ -38,8 +38,8 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
 - (void)mdc_swipeToChooseSetup:(MDCSwipeOptions *)options {
     self.mdc_options = options ? options : [MDCSwipeOptions new];
     self.mdc_viewState = [MDCViewState new];
-    self.mdc_viewState.originalCenter = self.center;
     self.mdc_viewState.originalTransform = self.layer.transform;
+    self.mdc_viewState.translation = CGPointZero;
 
     if (options.swipeEnabled) {
         [self mdc_setupPanGestureRecognizer];
@@ -60,9 +60,10 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
     void (^animations)(void) = ^{
         CGPoint translation = [self mdc_translationExceedingThreshold:self.mdc_options.threshold
                                                             direction:direction];
-        self.center = MDCCGPointAdd(self.center, translation);
-        [self mdc_rotateForTranslation:translation
-                     rotationDirection:MDCRotationAwayFromCenter];
+        
+        self.mdc_viewState.translation = translation;
+        self.mdc_viewState.rotationDirection = MDCRotationAwayFromCenter;
+        [self mdc_applyLayerTransform];
         [self mdc_executeOnPanBlockForTranslation:translation];
     };
 
@@ -123,9 +124,7 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
     switch (direction) {
         case MDCSwipeDirectionRight:
         case MDCSwipeDirectionLeft: {
-            CGPoint translation = MDCCGPointSubtract(self.center,
-                                                     self.mdc_viewState.originalCenter);
-            [self mdc_exitSuperviewFromTranslation:translation];
+            [self mdc_exitSuperviewFromTranslation:self.mdc_viewState.translation];
             break;
         }
         case MDCSwipeDirectionNone:
@@ -141,7 +140,6 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
                         options:self.mdc_options.swipeCancelledAnimationOptions
                      animations:^{
                          self.layer.transform = self.mdc_viewState.originalTransform;
-                         self.center = self.mdc_viewState.originalCenter;
                      } completion:^(BOOL finished) {
                          id<MDCSwipeToChooseDelegate> delegate = self.mdc_options.delegate;
                          if ([delegate respondsToSelector:@selector(viewDidCancelSwipe:)]) {
@@ -196,12 +194,16 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
     }
 }
 
-#pragma mark Rotation
-
-- (void)mdc_rotateForTranslation:(CGPoint)translation
-               rotationDirection:(MDCRotationDirection)rotationDirection {
+- (void)mdc_applyLayerTransform {
+    CATransform3D t = self.mdc_viewState.originalTransform;
+    
+    CGPoint translation = self.mdc_viewState.translation;
+    t = CATransform3DTranslate(t, translation.x, translation.y, 0);
+    
     CGFloat rotation = MDCDegreesToRadians(translation.x/100 * self.mdc_options.rotationFactor);
-    self.layer.transform = CATransform3DMakeRotation(rotationDirection * rotation, 0.0, 0.0, 1.0);
+    t = CATransform3DRotate(t, self.mdc_viewState.rotationDirection * rotation, 0, 0, 1);
+    
+    self.layer.transform = t;
 }
 
 #pragma mark Threshold
@@ -224,9 +226,9 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
 }
 
 - (MDCSwipeDirection)mdc_directionOfExceededThreshold {
-    if (self.center.x > self.mdc_viewState.originalCenter.x + self.mdc_options.threshold) {
+    if (self.mdc_viewState.translation.x > self.mdc_options.threshold) {
         return MDCSwipeDirectionRight;
-    } else if (self.center.x < self.mdc_viewState.originalCenter.x - self.mdc_options.threshold) {
+    } else if (self.mdc_viewState.translation.x < -self.mdc_options.threshold) {
         return MDCSwipeDirectionLeft;
     } else {
         return MDCSwipeDirectionNone;
@@ -239,8 +241,8 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
     UIView *view = panGestureRecognizer.view;
 
     if (panGestureRecognizer.state == UIGestureRecognizerStateBegan) {
-        self.mdc_viewState.originalCenter = view.center;
         self.mdc_viewState.originalTransform = view.layer.transform;
+        self.mdc_viewState.translation = CGPointZero;
 
         // If the pan gesture originated at the top half of the view, rotate the view
         // away from the center. Otherwise, rotate towards the center.
@@ -257,11 +259,9 @@ const void * const MDCViewStateKey = &MDCViewStateKey;
     } else {
         // Update the position and transform. Then, notify any listeners of
         // the updates via the pan block.
-        CGPoint translation = [panGestureRecognizer translationInView:view];
-        view.center = MDCCGPointAdd(self.mdc_viewState.originalCenter, translation);
-        [self mdc_rotateForTranslation:translation
-                     rotationDirection:self.mdc_viewState.rotationDirection];
-        [self mdc_executeOnPanBlockForTranslation:translation];
+        self.mdc_viewState.translation = [panGestureRecognizer translationInView:view];
+        [self mdc_applyLayerTransform];
+        [self mdc_executeOnPanBlockForTranslation:self.mdc_viewState.translation];
     }
 }
 


### PR DESCRIPTION
This allows the swipe gesture/animation to work with views that are affected by Autolayout constraints.