### PR TITLE
Fix mini typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ To use objective-c code from swift, you need to use bridging-header.
 ```swift
 import UIKit
 
-// ... in a view controller that confirms to MDCSwipeToChooseDelegate protocol
+// ... in a view controller that conforms to MDCSwipeToChooseDelegate protocol
 
 override func viewDidLoad() {
     super.viewDidLoad()


### PR DESCRIPTION
From "conf**i**rms to protocol" to "conf**o**rms to protocol"